### PR TITLE
Adding support for CommonJS module loaders (e.g. Webpack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A pure-javascript integration tester for AngularJS that can be run inline with a
 ## Installation
 
 1. run `npm install ng-midway-tester`.
-2. include `./node_modules/ngMidwayTester/src/ngMidwayTester.js` into your test runner.
+2. If using Webpack or Browserify then simply use `var ngMidwayTester = require('ng-midway-tester');`.
+3. Otherwise, include `./node_modules/ngMidwayTester/src/ngMidwayTester.js` into your test runner.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-A fork from [ng-midway-tester](https://github.com/yearofmoo/ngMidwayTester)
- 
 
 # ngMidwayTester [![Build Status](https://travis-ci.org/yearofmoo/ngMidwayTester.png?branch=master)](https://travis-ci.org/yearofmoo/ngMidwayTester)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+A fork from [ng-midway-tester](https://github.com/yearofmoo/ngMidwayTester)
+ 
+
 # ngMidwayTester [![Build Status](https://travis-ci.org/yearofmoo/ngMidwayTester.png?branch=master)](https://travis-ci.org/yearofmoo/ngMidwayTester)
 
 A pure-javascript integration tester for AngularJS that can be run inline with application code.  

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 require('./src/ngMidwayTester');
-module.exports = ngMidwayTester;
+module.exports = window.ngMidwayTester;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./src/ngMidwayTester');
+module.exports = ngMidwayTester;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ng-midway-tester",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "repository": {
     "type": "git",
-    "url": "git@github.com:yearofmoo/ngMidwayTester.git"
+    "url": "git@github.com:motevallian/ngMidwayTester.git"
   },
   "scripts": {
     "test": "grunt travis"

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
     "grunt-shell": "~0.5.0",
     "grunt-open": "~0.2.2",
     "karma-script-launcher": "~0.1.0",
-    "karma-chrome-launcher": "~0.1.0",
-    "karma-firefox-launcher": "~0.1.0",
+    "karma-chrome-launcher": "~0.2.0",
+    "karma-firefox-launcher": "~0.1.6",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.3",
-    "karma-requirejs": "~0.1.0",
-    "karma-coffee-preprocessor": "~0.1.0",
-    "karma-phantomjs-launcher": "~0.1.0",
-    "karma": "~0.10.2",
-    "grunt-karma": "~0.6.2",
+    "karma-requirejs": "~0.2.2",
+    "karma-coffee-preprocessor": "~0.3.0",
+    "karma-phantomjs-launcher": "~0.2.0",
+    "karma": "~0.12.37",
+    "grunt-karma": "~0.11.2",
     "mocha": "~1.13.0",
     "karma-mocha": "~0.1.0",
     "chai": "~1.8.1",
-    "karma-coverage": "~0.1.0"
+    "karma-coverage": "~0.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.6",
   "repository": {
     "type": "git",
-    "url": "git@github.com:motevallian/ngMidwayTester.git"
+    "url": "git@github.com:yearofmoo/ngMidwayTester.git"
   },
   "scripts": {
     "test": "grunt travis"

--- a/src/ngMidwayTester.js
+++ b/src/ngMidwayTester.js
@@ -263,3 +263,5 @@
     }
   };
 };
+
+window.ngMidwayTester = ngMidwayTester;


### PR DESCRIPTION
I have created an `index.js` file which loads the original source and exports it to be used by Webpack/Browserify.
As Webpack confines variables in local scopes I exposed the `ngMidwayTester` function as a property of `window` so that `index.js` can get a hold of it.
The same approach is adopted by `angular` on `npm`.